### PR TITLE
Use feature-gates to enable or disable pod resources API

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -855,6 +855,7 @@ func RunKubelet(ctx context.Context, kubeServer *options.KubeletServer, kubeDeps
 		klog.ErrorS(err, "Failed to set rlimit on max file handles")
 	}
 
+
 	startKubelet(k, podCfg, &kubeServer.KubeletConfiguration, kubeDeps, kubeServer.EnableServer)
 	klog.InfoS("Started kubelet")
 	return nil
@@ -868,6 +869,7 @@ func startKubelet(k kubelet.Bootstrap, podCfg *config.PodConfig, kubeCfg *kubele
 	if kubeCfg.ReadOnlyPort > 0 {
 		go k.ListenAndServeReadOnly(kubeCfg, kubeDeps.TracerProvider)
 	}
+	go k.ListenAndServePodResources()
 }
 
 func createAndInitKubelet(kubeServer *options.KubeletServer,

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -855,7 +855,6 @@ func RunKubelet(ctx context.Context, kubeServer *options.KubeletServer, kubeDeps
 		klog.ErrorS(err, "Failed to set rlimit on max file handles")
 	}
 
-
 	startKubelet(k, podCfg, &kubeServer.KubeletConfiguration, kubeDeps, kubeServer.EnableServer)
 	klog.InfoS("Started kubelet")
 	return nil
@@ -869,7 +868,10 @@ func startKubelet(k kubelet.Bootstrap, podCfg *config.PodConfig, kubeCfg *kubele
 	if kubeCfg.ReadOnlyPort > 0 {
 		go k.ListenAndServeReadOnly(kubeCfg, kubeDeps.TracerProvider)
 	}
-	go k.ListenAndServePodResources()
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResources) {
+		go k.ListenAndServePodResources()
+	}
 }
 
 func createAndInitKubelet(kubeServer *options.KubeletServer,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -385,6 +385,12 @@ const (
 	// All the node components such as CRI need to be running in the same user namespace.
 	KubeletInUserNamespace featuregate.Feature = "KubeletInUserNamespace"
 
+	// owner: @kubeedge
+	// alpha: v1.31.12-kubeedge2
+	//
+	// Enables the kubelet's pod resources grpc endpoint
+	KubeletPodResources featuregate.Feature = "KubeletPodResources"
+
 	// owner: @moshe010
 	// alpha: v1.27
 	//
@@ -1102,6 +1108,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	KubeletCgroupDriverFromCRI: {Default: true, PreRelease: featuregate.Beta},
 
 	KubeletInUserNamespace: {Default: false, PreRelease: featuregate.Alpha},
+
+	KubeletPodResources: {Default: false, PreRelease: featuregate.Alpha},
 
 	KubeletPodResourcesDynamicResources: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/apis/podresources/client.go
+++ b/pkg/kubelet/apis/podresources/client.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podresources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"k8s.io/cri-client/pkg/util"
+	"k8s.io/kubelet/pkg/apis/podresources/v1"
+	"k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
+)
+
+// Note: Consumers of the pod resources API should not be importing this package.
+// They should copy paste the function in their project.
+
+// GetV1alpha1Client returns a client for the PodResourcesLister grpc service
+// Note: This is deprecated
+func GetV1alpha1Client(socket string, connectionTimeout time.Duration, maxMsgSize int) (v1alpha1.PodResourcesListerClient, *grpc.ClientConn, error) {
+	addr, dialer, err := util.GetAddressAndDialer(socket)
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(dialer),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	if err != nil {
+		return nil, nil, fmt.Errorf("error dialing socket %s: %v", socket, err)
+	}
+	return v1alpha1.NewPodResourcesListerClient(conn), conn, nil
+}
+
+// GetV1Client returns a client for the PodResourcesLister grpc service
+func GetV1Client(socket string, connectionTimeout time.Duration, maxMsgSize int) (v1.PodResourcesListerClient, *grpc.ClientConn, error) {
+	addr, dialer, err := util.GetAddressAndDialer(socket)
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(dialer),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	if err != nil {
+		return nil, nil, fmt.Errorf("error dialing socket %s: %v", socket, err)
+	}
+	return v1.NewPodResourcesListerClient(conn), conn, nil
+}

--- a/pkg/kubelet/apis/podresources/server_v1alpha1.go
+++ b/pkg/kubelet/apis/podresources/server_v1alpha1.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podresources
+
+import (
+	"context"
+
+	"k8s.io/kubernetes/pkg/kubelet/metrics"
+
+	"k8s.io/kubelet/pkg/apis/podresources/v1"
+	"k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
+)
+
+// v1alpha1PodResourcesServer implements PodResourcesListerServer
+type v1alpha1PodResourcesServer struct {
+	podsProvider    PodsProvider
+	devicesProvider DevicesProvider
+}
+
+// NewV1alpha1PodResourcesServer returns a PodResourcesListerServer which lists pods provided by the PodsProvider
+// with device information provided by the DevicesProvider
+func NewV1alpha1PodResourcesServer(providers PodResourcesProviders) v1alpha1.PodResourcesListerServer {
+	return &v1alpha1PodResourcesServer{
+		podsProvider:    providers.Pods,
+		devicesProvider: providers.Devices,
+	}
+}
+
+func v1DevicesToAlphaV1(alphaDevs []*v1.ContainerDevices) []*v1alpha1.ContainerDevices {
+	var devs []*v1alpha1.ContainerDevices
+	for _, alphaDev := range alphaDevs {
+		dev := v1alpha1.ContainerDevices{
+			ResourceName: alphaDev.ResourceName,
+			DeviceIds:    alphaDev.DeviceIds,
+		}
+		devs = append(devs, &dev)
+	}
+
+	return devs
+}
+
+// List returns information about the resources assigned to pods on the node
+func (p *v1alpha1PodResourcesServer) List(ctx context.Context, req *v1alpha1.ListPodResourcesRequest) (*v1alpha1.ListPodResourcesResponse, error) {
+	metrics.PodResourcesEndpointRequestsTotalCount.WithLabelValues("v1alpha1").Inc()
+	pods := p.podsProvider.GetPods()
+	podResources := make([]*v1alpha1.PodResources, len(pods))
+	p.devicesProvider.UpdateAllocatedDevices()
+
+	for i, pod := range pods {
+		pRes := v1alpha1.PodResources{
+			Name:       pod.Name,
+			Namespace:  pod.Namespace,
+			Containers: make([]*v1alpha1.ContainerResources, len(pod.Spec.Containers)),
+		}
+
+		for j, container := range pod.Spec.Containers {
+			pRes.Containers[j] = &v1alpha1.ContainerResources{
+				Name:    container.Name,
+				Devices: v1DevicesToAlphaV1(p.devicesProvider.GetDevices(string(pod.UID), container.Name)),
+			}
+		}
+		podResources[i] = &pRes
+	}
+
+	return &v1alpha1.ListPodResourcesResponse{
+		PodResources: podResources,
+	}, nil
+}


### PR DESCRIPTION
Revert d3ad4e4512dddc4ae64c9b2023d01aa9e8285d18 and add a feature-gate to enable pod resource API.

As mentioned in the issue https://github.com/kubeedge/kubeedge/issues/6327, we still need pod resource API in some scenarios.

```golang
func TestNewFeatureGates(t *testing.T) {
	var b bool
	b = utilfeature.DefaultMutableFeatureGate.Enabled(KubeletPodResources)
	t.Log(b) // False
	err := utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{"KubeletPodResources": true})
	if err != nil {
		t.Fatal(err)
	}
	b = utilfeature.DefaultMutableFeatureGate.Enabled(KubeletPodResources)
	t.Log(b) // True
}
```

```text
Output:
=== RUN   TestNewFeatureGates
    /.../github.com/kubeedge/kubernetes/pkg/features/kube_features_test.go:80: false
    /.../github.com/kubeedge/kubernetes/pkg/features/kube_features_test.go:86: true
--- PASS: TestNewFeatureGates (0.00s)
PASS
ok  	k8s.io/kubernetes/pkg/features	0.865s
```