### PR TITLE
Use feature-gates to enable or disable CSI volume plugin

### DIFF
--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -60,7 +60,9 @@ func ProbeVolumePlugins(featureGate featuregate.FeatureGate) ([]volume.VolumePlu
 	allPlugins = append(allPlugins, configmap.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, projected.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, local.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, csi.ProbeVolumePlugins()...)
+	if !featureGate.Enabled(features.DisableCSIVolumePlugin) {
+		allPlugins = append(allPlugins, csi.ProbeVolumePlugins()...)
+	}
 	if featureGate.Enabled(features.ImageVolume) {
 		allPlugins = append(allPlugins, image.ProbeVolumePlugins()...)
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -218,6 +218,12 @@ const (
 	// Disable any functionality in kube-apiserver, kube-controller-manager and kubelet related to the `--cloud-provider` component flag.
 	DisableCloudProviders featuregate.Feature = "DisableCloudProviders"
 
+	// owner: @kubeedge
+	// alpha: v1.31.12-kubeedge2
+	//
+	// DisableCSIVolumePlugin disables the in-tree CSI volume plugin support.
+	DisableCSIVolumePlugin featuregate.Feature = "DisableCSIVolumePlugin"
+
 	// owner: @andrewsykim
 	// alpha: v1.23
 	// beta: v1.29
@@ -1060,6 +1066,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	DisableAllocatorDualWrite: {Default: false, PreRelease: featuregate.Alpha}, // remove after MultiCIDRServiceAllocator is GA
 
 	DisableCloudProviders: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+
+	DisableCSIVolumePlugin: {Default: false, PreRelease: featuregate.Alpha},
 
 	DisableKubeletCloudCredentialProviders: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 


### PR DESCRIPTION
Move the feature-gate for enabling or disabling the CSI volume plugin to K8s. Reference https://github.com/kubeedge/kubeedge/issues/6232.

```golang
func TestNewFeatureGates(t *testing.T) {
    var b bool
    b = utilfeature.DefaultMutableFeatureGate.Enabled(DisableCSIVolumePlugin)
    t.Log(b) // False
    err := utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{"DisableCSIVolumePlugin": true})
    if err != nil {
        t.Fatal(err)
    }
    b = utilfeature.DefaultMutableFeatureGate.Enabled(DisableCSIVolumePlugin)
    t.Log(b) // True
}
```
```text
Output:
=== RUN   TestNewFeatureGates
    /.../github.com/kubeedge/kubernetes/pkg/features/kube_features_test.go:80: false
    /.../github.com/kubeedge/kubernetes/pkg/features/kube_features_test.go:86: true
--- PASS: TestNewFeatureGates (0.00s)
PASS
ok  	k8s.io/kubernetes/pkg/features	0.643s
```